### PR TITLE
Merge release/3.0.0 into master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,8 +2,5 @@
 /.vagrant
 /*-cloudimg-console.log
 
-# IDE files
-/.idea
-
 # Composer files
 /vendor

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,9 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PhpFullyQualifiedNameUsageInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="IGNORE_GLOBAL_NAMESPACE" value="true" />
+    </inspection_tool>
+    <inspection_tool class="PhpUnhandledExceptionInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,6 +1,7 @@
 <component name="InspectionProjectProfileManager">
   <profile version="1.0">
     <option name="myName" value="Project Default" />
+    <inspection_tool class="PhpDocMissingThrowsInspection" enabled="false" level="WEAK WARNING" enabled_by_default="false" />
     <inspection_tool class="PhpFullyQualifiedNameUsageInspection" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="IGNORE_GLOBAL_NAMESPACE" value="true" />
     </inspection_tool>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/prometheus-client.iml" filepath="$PROJECT_DIR$/.idea/prometheus-client.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpIncludePathManager">
+    <include_path>
+      <path value="$PROJECT_DIR$/vendor/sebastian/global-state" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/object-enumerator" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/recursion-context" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/resource-operations" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/version" />
+      <path value="$PROJECT_DIR$/vendor/webmozart/assert" />
+      <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-common" />
+      <path value="$PROJECT_DIR$/vendor/phpdocumentor/reflection-docblock" />
+      <path value="$PROJECT_DIR$/vendor/phpdocumentor/type-resolver" />
+      <path value="$PROJECT_DIR$/vendor/composer" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-token-stream" />
+      <path value="$PROJECT_DIR$/vendor/symfony/polyfill-ctype" />
+      <path value="$PROJECT_DIR$/vendor/symfony/yaml" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/exporter" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/environment" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/diff" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-text-template" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-timer" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/phpunit-mock-objects" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/comparator" />
+      <path value="$PROJECT_DIR$/vendor/doctrine/instantiator" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-file-iterator" />
+      <path value="$PROJECT_DIR$/vendor/sebastian/code-unit-reverse-lookup" />
+      <path value="$PROJECT_DIR$/vendor/myclabs/deep-copy" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/php-code-coverage" />
+      <path value="$PROJECT_DIR$/vendor/phpspec/prophecy" />
+      <path value="$PROJECT_DIR$/vendor/phpunit/phpunit" />
+    </include_path>
+  </component>
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.3" />
+  <component name="PhpUnit">
+    <phpunit_settings>
+      <PhpUnitSettings configuration_file_path="$PROJECT_DIR$/phpunit.xml.dist" custom_loader_path="$PROJECT_DIR$/vendor/autoload.php" use_configuration_file="true" />
+    </phpunit_settings>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -29,6 +29,9 @@
       <path value="$PROJECT_DIR$/vendor/phpunit/php-code-coverage" />
       <path value="$PROJECT_DIR$/vendor/phpspec/prophecy" />
       <path value="$PROJECT_DIR$/vendor/phpunit/phpunit" />
+      <path value="$PROJECT_DIR$/vendor/psr/container" />
+      <path value="$PROJECT_DIR$/vendor/symfony/service-contracts" />
+      <path value="$PROJECT_DIR$/vendor/symfony/stopwatch" />
     </include_path>
   </component>
   <component name="PhpProjectSharedConfiguration" php_language_level="7.3" />

--- a/.idea/phpunit.xml
+++ b/.idea/phpunit.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PHPUnit">
+    <option name="directories">
+      <list>
+        <option value="$PROJECT_DIR$/tests" />
+      </list>
+    </option>
+  </component>
+</project>

--- a/.idea/prometheus-client.iml
+++ b/.idea/prometheus-client.iml
@@ -20,6 +20,7 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-token-stream" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/phpunit" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/phpunit-mock-objects" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/psr/container" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/code-unit-reverse-lookup" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/comparator" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/diff" />
@@ -31,6 +32,8 @@
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/resource-operations" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/version" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-ctype" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/service-contracts" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/stopwatch" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/yaml" />
       <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
     </content>

--- a/.idea/prometheus-client.iml
+++ b/.idea/prometheus-client.iml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" packagePrefix="DaybreakStudios\PrometheusClient\" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" packagePrefix="Tests\DaybreakStudios\PrometheusClient\" />
+      <excludeFolder url="file://$MODULE_DIR$/.vagrant" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/composer" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/doctrine/instantiator" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/myclabs/deep-copy" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-common" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/reflection-docblock" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpdocumentor/type-resolver" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpspec/prophecy" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-code-coverage" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-file-iterator" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-text-template" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-timer" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/php-token-stream" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/phpunit" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/phpunit/phpunit-mock-objects" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/code-unit-reverse-lookup" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/comparator" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/diff" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/environment" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/exporter" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/global-state" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/object-enumerator" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/recursion-context" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/resource-operations" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/sebastian/version" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/polyfill-ctype" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/symfony/yaml" />
+      <excludeFolder url="file://$MODULE_DIR$/vendor/webmozart/assert" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ using.
 
 ```php
 <?php
-    use DaybreakStudios\PrometheusClient\Adapter\ApcuAdapter;
+    use DaybreakStudios\PrometheusClient\Adapter\Apcu\ApcuAdapter;
     
     $adapter = new ApcuAdapter();
 ```
@@ -123,12 +123,12 @@ below.
 This library provides access to the underlying storage system via adapters. The built-in adapters are documented below.
 
 ### Redis
-The `DaybreakStudios\PrometheusClient\Adapter\RedisAdapter` uses Redis to store metrics. To use the Redis adapter, you
-simply need to provide it with the host of the Redis instance.
+The `DaybreakStudios\PrometheusClient\Adapter\Redis\RedisAdapter` uses Redis to store metrics. To use the Redis adapter,
+you simply need to provide it with the host of the Redis instance.
 
 ```php
 <?php
-    use DaybreakStudios\PrometheusClient\Adapter\RedisAdapter;
+    use DaybreakStudios\PrometheusClient\Adapter\Redis\RedisAdapter;
     use DaybreakStudios\PrometheusClient\Adapter\Redis\RedisClientConfiguration;
 
     $config = new RedisClientConfiguration('localhost');
@@ -146,15 +146,15 @@ your Redis instance. By default, the prefix is "dbstudios_prom:", but you can ch
 to the constructor of `RedisClientConfiguration`.
 
 ### Filesystem
-The `DaybreakStudios\PrometheusClient\Adapter\FilesystemAdapter` uses files to store metrics. Data written to the
-adapter's files is encoded using PHP's [`serialize()`](http://php.net/manual/en/function.serialize.php) function, so
+The `DaybreakStudios\PrometheusClient\Adapter\Filesystem\FilesystemAdapter` uses files to store metrics. Data written to
+the adapter's files is encoded using PHP's [`serialize()`](http://php.net/manual/en/function.serialize.php) function, so
 types will be properly preserved. To use the `FilesystemAdapter`, you will need to specify which directory the adapter
 should use to store it's files. In order to prevent data loss, the directory you specify should _only_ be used by
 Prometheus.
 
 ```php
 <?php
-    use DaybreakStudios\PrometheusClient\Adapter\FilesystemAdapter;
+    use DaybreakStudios\PrometheusClient\Adapter\Filesystem\FilesystemAdapter;
     
     $adapter = new FilesystemAdapter('/var/www/html/prometheus');
 ```
@@ -164,8 +164,8 @@ Unlike the [APCu adapter](#apcu), cached data will persist, even if your server 
 delete _everything_ in the directory you specified as the adapter's base directory.
 
 ### APCu
-The `DaybreakStudios\PrometheusClient\Adapter\ApcuAdapter` uses [APCu](http://php.net/manual/en/book.apcu.php) to store
-metrics. The APCU adapter uses no additional configuration.
+The `DaybreakStudios\PrometheusClient\Adapter\Apcu\ApcuAdapter` uses [APCu](http://php.net/manual/en/book.apcu.php) to
+store metrics. The APCU adapter uses no additional configuration.
 
 There are a few pitfalls to be aware of, however. APCu, by default, does not persist stored data through certain events,
 such as a server reboot. Additionally, it also wipes its entire cache once the cache fills up. Neither of those

--- a/README.md
+++ b/README.md
@@ -214,7 +214,9 @@ hours you throw at it_).
     $histogram->observe(7010);
 ```
 
-Since histograms are often used for timing, there are two built-in utility methods for working with time.
+Since histograms are often used for timing, there are two built-in utility methods for working with time. Please note
+that you will need to install the [`symfony/stopwatch`](https://symfony.com/doc/current/components/stopwatch.html)
+component in order to use timing features.
 
 ```php
 <?php

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,9 +28,12 @@ Vagrant.configure("2") do |config|
 		fi
 
 		apt-get install -y php-apcu
-		apt-get remove php7*
 
 		phpenmod apcu
+
+		apt-get install -y redis-server
+		systemctl enable redis-server
+		systemctl start redis-server
 	SHELL
 
 	config.vm.provision "shell", privileged: false, inline: <<-SHELL

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,16 +15,16 @@ Vagrant.configure("2") do |config|
 
 		add-apt-repository -y ppa:ondrej/php
 
-		apt-get install -y php5.6-common php5.6-cli php5.6-curl php5.6-zip php5.6-mbstring php5.6-xml php5.6-dom \
-			php5.6-xdebug
+		apt-get install -y php7.3-common php7.3-cli php7.3-curl php7.3-zip php7.3-mbstring php7.3-xml php7.3-dom \
+			php7.3-xdebug php7.3-redis
 		apt-get install -y composer
 
-		if grep -Fqvx "xdebug.remote_enable" /etc/php/5.6/mods-available/xdebug.ini; then
-			echo "xdebug.remote_enable = on" >> /etc/php/5.6/mods-available/xdebug.ini
-			echo "xdebug.remote_connect_back = on" >> /etc/php/5.6/mods-available/xdebug.ini
-			echo "xdebug.idekey = application" >> /etc/php/5.6/mods-available/xdebug.ini
-			echo "xdebug.remote_autostart = off" >> /etc/php/5.6/mods-available/xdebug.ini
-			echo "xdebug.remote_host = 10.0.2.2" >> /etc/php/5.6/mods-available/xdebug.ini
+		if grep -Fqvx "xdebug.remote_enable" /etc/php/7.3/mods-available/xdebug.ini; then
+			echo "xdebug.remote_enable = on" >> /etc/php/7.3/mods-available/xdebug.ini
+			echo "xdebug.remote_connect_back = on" >> /etc/php/7.3/mods-available/xdebug.ini
+			echo "xdebug.idekey = application" >> /etc/php/7.3/mods-available/xdebug.ini
+			echo "xdebug.remote_autostart = off" >> /etc/php/7.3/mods-available/xdebug.ini
+			echo "xdebug.remote_host = 10.0.2.2" >> /etc/php/7.3/mods-available/xdebug.ini
 		fi
 
 		apt-get install -y php-apcu

--- a/composer.json
+++ b/composer.json
@@ -12,11 +12,11 @@
 	],
 	"require": {
 		"php": ">=7.3",
-		"ext-json": "*",
-		"ext-redis": "*"
+		"ext-json": "*"
 	},
 	"require-dev": {
 		"ext-apcu": "*",
+		"ext-redis": "*",
 		"phpunit/phpunit": "^5.0",
 		"symfony/stopwatch": "^5.1"
 	},

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,13 @@
 	},
 	"require-dev": {
 		"ext-apcu": "*",
-		"phpunit/phpunit": "^5.0"
+		"phpunit/phpunit": "^5.0",
+		"symfony/stopwatch": "^5.1"
 	},
 	"suggest": {
-		"ext-apcu": "If you want to use the APCu adapter"
+		"ext-apcu": "If you want to use the APCu adapter",
+		"ext-redis": "If you want to use the Redis adapter",
+		"symfony/stopwatch": "If you want to use the Histogram timing features"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
 		}
 	],
 	"require": {
-		"php": ">=5.6",
+		"php": ">=7.3",
 		"ext-json": "*"
 	},
 	"require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
 		"ext-apcu": "*",
 		"ext-redis": "*",
 		"phpunit/phpunit": "^5.0",
-		"symfony/stopwatch": "^5.1"
+		"symfony/stopwatch": "^4.4|^5.1"
 	},
 	"suggest": {
 		"ext-apcu": "If you want to use the APCu adapter",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
 	],
 	"require": {
 		"php": ">=7.3",
-		"ext-json": "*"
+		"ext-json": "*",
+		"ext-redis": "*"
 	},
 	"require-dev": {
 		"ext-apcu": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,37 +4,39 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "06529ef0a78e13d011dc1031c48e1538",
+    "content-hash": "5cb9322c59386f42d1e3a35125bf2e99",
     "packages": [],
     "packages-dev": [
         {
             "name": "doctrine/instantiator",
-            "version": "1.0.5",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d"
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/8e884e78f9f0eb1329e445619e04456e64d8051d",
-                "reference": "8e884e78f9f0eb1329e445619e04456e64d8051d",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3,<8.0-DEV"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "athletic/athletic": "~0.1.8",
+                "doctrine/coding-standard": "^6.0",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpunit/phpunit": "~4.0",
-                "squizlabs/php_codesniffer": "~2.0"
+                "phpbench/phpbench": "^0.13",
+                "phpstan/phpstan-phpunit": "^0.11",
+                "phpstan/phpstan-shim": "^0.11",
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "1.2.x-dev"
                 }
             },
             "autoload": {
@@ -54,34 +56,37 @@
                 }
             ],
             "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://github.com/doctrine/instantiator",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
             "keywords": [
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14T21:17:01+00:00"
+            "time": "2020-05-29T17:27:14+00:00"
         },
         {
             "name": "myclabs/deep-copy",
-            "version": "1.7.0",
+            "version": "1.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/myclabs/DeepCopy.git",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e"
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
-                "reference": "3b8a3a99ba1f6a3952ac2747d989303cbd6b7a3e",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
+                "reference": "969b211f9a51aa1f6c01d1d2aef56d3bd91598e5",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0"
+                "php": "^7.1 || ^8.0"
+            },
+            "replace": {
+                "myclabs/deep-copy": "self.version"
             },
             "require-dev": {
                 "doctrine/collections": "^1.0",
                 "doctrine/common": "^2.6",
-                "phpunit/phpunit": "^4.1"
+                "phpunit/phpunit": "^7.1"
             },
             "type": "library",
             "autoload": {
@@ -104,39 +109,34 @@
                 "object",
                 "object graph"
             ],
-            "time": "2017-10-19T19:58:43+00:00"
+            "time": "2020-06-29T13:22:24+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
-            "version": "1.0.1",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6"
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
-                "reference": "21bdeb5f65d7ebf9f43b1b25d404f87deab5bfb6",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.6"
+                "php": "^7.2 || ^8.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-2.x": "2.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -158,86 +158,90 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2017-09-11T18:02:19+00:00"
+            "time": "2020-06-27T09:03:43+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "3.3.2",
+            "version": "5.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2"
+                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/bf329f6c1aadea3299f08ee804682b7c45b326a2",
-                "reference": "bf329f6c1aadea3299f08ee804682b7c45b326a2",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d870572532cd70bc3fab58f2e23ad423c8404c44",
+                "reference": "d870572532cd70bc3fab58f2e23ad423c8404c44",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.6 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0.0",
-                "phpdocumentor/type-resolver": "^0.4.0",
-                "webmozart/assert": "^1.0"
+                "ext-filter": "*",
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^1.3",
+                "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^4.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Mike van Riel",
-                    "email": "me@mikevanriel.com"
-                }
-            ],
-            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
-            "time": "2017-11-10T14:09:06+00:00"
-        },
-        {
-            "name": "phpdocumentor/type-resolver",
-            "version": "0.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "reference": "9c977708995954784726e25d0cd1dddf4e65b0f7",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.5 || ^7.0",
-                "phpdocumentor/reflection-common": "^1.0"
-            },
-            "require-dev": {
-                "mockery/mockery": "^0.9.4",
-                "phpunit/phpunit": "^5.2||^4.8.24"
+                "mockery/mockery": "~1.3.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "5.x-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "phpDocumentor\\Reflection\\": [
-                        "src/"
-                    ]
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "account@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2020-08-15T11:14:08+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e878a14a65245fbe78f8080eba03b47c3b705651",
+                "reference": "e878a14a65245fbe78f8080eba03b47c3b705651",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -250,42 +254,43 @@
                     "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2017-07-14T14:27:02+00:00"
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "time": "2020-06-27T10:12:23+00:00"
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.8.0",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
-                "reference": "4ba436b55987b4bf311cb7c6ba82aa528aac0a06",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0",
-                "sebastian/comparator": "^1.1|^2.0|^3.0",
-                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2|^4.0|^5.0",
+                "sebastian/comparator": "^1.2.3|^2.0|^3.0|^4.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0|^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^2.5|^3.2",
+                "phpspec/phpspec": "^2.5 || ^3.2",
                 "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.5 || ^7.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.8.x-dev"
+                    "dev-master": "1.10.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Prophecy\\": "src/"
+                "psr-4": {
+                    "Prophecy\\": "src/Prophecy"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -313,7 +318,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-08-05T17:53:17+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -517,29 +522,29 @@
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.12",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16"
+                "reference": "791198a2c6254db10131eecfe8c06670700904db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/1ce90ba27c42e4e44e6d8458241466380b51fa16",
-                "reference": "1ce90ba27c42e4e44e6d8458241466380b51fa16",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
+                "reference": "791198a2c6254db10131eecfe8c06670700904db",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": ">=5.3.3"
+                "php": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.2"
+                "phpunit/phpunit": "^6.2.4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -562,7 +567,8 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-12-04T08:55:13+00:00"
+            "abandoned": true,
+            "time": "2017-11-27T05:48:46+00:00"
         },
         {
             "name": "phpunit/phpunit",
@@ -1270,16 +1276,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.10.0",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19"
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e3d826245268269cd66f8326bd8bc066687b4a19",
-                "reference": "e3d826245268269cd66f8326bd8bc066687b4a19",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1c302646f6efc070cd46856e600e5e0684d6b454",
+                "reference": "1c302646f6efc070cd46856e600e5e0684d6b454",
                 "shasum": ""
             },
             "require": {
@@ -1291,7 +1297,11 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.9-dev"
+                    "dev-master": "1.18-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
                 }
             },
             "autoload": {
@@ -1308,12 +1318,12 @@
             ],
             "authors": [
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
                 },
                 {
-                    "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -1324,20 +1334,20 @@
                 "polyfill",
                 "portable"
             ],
-            "time": "2018-08-06T14:22:27+00:00"
+            "time": "2020-07-14T12:35:20+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v2.1.3",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442"
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/58c7475e5457c5492c26cc740cc0ad7464be9442",
-                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/d15da7ba4957ffb8f1747218be9e1a121fd298a1",
+                "reference": "d15da7ba4957ffb8f1747218be9e1a121fd298a1",
                 "shasum": ""
             },
             "require": {
@@ -1350,7 +1360,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.1-dev"
+                    "dev-master": "2.2-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -1386,7 +1396,7 @@
                 "interoperability",
                 "standards"
             ],
-            "time": "2020-07-06T13:23:11+00:00"
+            "time": "2020-09-07T11:33:47+00:00"
         },
         {
             "name": "symfony/stopwatch",
@@ -1440,27 +1450,27 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v3.4.23",
+            "version": "v4.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c"
+                "reference": "e2a69525b11a33be51cb00b8d6d13a9258a296b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/57f1ce82c997f5a8701b89ef970e36bb657fd09c",
-                "reference": "57f1ce82c997f5a8701b89ef970e36bb657fd09c",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e2a69525b11a33be51cb00b8d6d13a9258a296b1",
+                "reference": "e2a69525b11a33be51cb00b8d6d13a9258a296b1",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.5.9|>=7.0.8",
+                "php": ">=7.1.3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
                 "symfony/console": "<3.4"
             },
             "require-dev": {
-                "symfony/console": "~3.4|~4.0"
+                "symfony/console": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "symfony/console": "For validating YAML files using the lint command"
@@ -1468,7 +1478,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.4-dev"
+                    "dev-master": "4.4-dev"
                 }
             },
             "autoload": {
@@ -1495,36 +1505,34 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2019-02-23T15:06:07+00:00"
+            "time": "2020-08-26T08:30:46+00:00"
         },
         {
             "name": "webmozart/assert",
-            "version": "1.4.0",
+            "version": "1.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9"
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/83e253c8e0be5b0257b881e1827274667c5c17a9",
-                "reference": "83e253c8e0be5b0257b881e1827274667c5c17a9",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/bafc69caeb4d49c39fd0779086c03a3738cbb389",
+                "reference": "bafc69caeb4d49c39fd0779086c03a3738cbb389",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0",
+                "php": "^5.3.3 || ^7.0 || ^8.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
+            "conflict": {
+                "phpstan/phpstan": "<0.12.20",
+                "vimeo/psalm": "<3.9.1"
+            },
             "require-dev": {
-                "phpunit/phpunit": "^4.6",
-                "sebastian/version": "^1.0.1"
+                "phpunit/phpunit": "^4.8.36 || ^7.5.13"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Webmozart\\Assert\\": "src/"
@@ -1546,7 +1554,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2018-12-25T11:19:39+00:00"
+            "time": "2020-07-08T17:02:28+00:00"
         }
     ],
     "aliases": [],
@@ -1556,10 +1564,10 @@
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.3",
-        "ext-json": "*",
-        "ext-redis": "*"
+        "ext-json": "*"
     },
     "platform-dev": {
-        "ext-apcu": "*"
+        "ext-apcu": "*",
+        "ext-redis": "*"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "17a952474634df8e796f33a2b93074e0",
+    "content-hash": "06529ef0a78e13d011dc1031c48e1538",
     "packages": [],
     "packages-dev": [
         {
@@ -707,6 +707,55 @@
             "time": "2017-06-30T09:13:00+00:00"
         },
         {
+            "name": "psr/container",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "reference": "b7ce3b176482dbbc1245ebf52b181af44c2cf55f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
             "name": "sebastian/code-unit-reverse-lookup",
             "version": "1.0.1",
             "source": {
@@ -1278,6 +1327,118 @@
             "time": "2018-08-06T14:22:27+00:00"
         },
         {
+            "name": "symfony/service-contracts",
+            "version": "v2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "reference": "58c7475e5457c5492c26cc740cc0ad7464be9442",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/container": "^1.0"
+            },
+            "suggest": {
+                "symfony/service-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "time": "2020-07-06T13:23:11+00:00"
+        },
+        {
+            "name": "symfony/stopwatch",
+            "version": "v5.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/stopwatch.git",
+                "reference": "0f7c58cf81dbb5dd67d423a89d577524a2ec0323"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/0f7c58cf81dbb5dd67d423a89d577524a2ec0323",
+                "reference": "0f7c58cf81dbb5dd67d423a89d577524a2ec0323",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "symfony/service-contracts": "^1.0|^2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Stopwatch\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Stopwatch Component",
+            "homepage": "https://symfony.com",
+            "time": "2020-05-20T17:43:50+00:00"
+        },
+        {
             "name": "symfony/yaml",
             "version": "v3.4.23",
             "source": {
@@ -1394,8 +1555,9 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.6",
-        "ext-json": "*"
+        "php": ">=7.3",
+        "ext-json": "*",
+        "ext-redis": "*"
     },
     "platform-dev": {
         "ext-apcu": "*"

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -9,7 +9,7 @@
 		 *
 		 * @return bool
 		 */
-		public function exists($key);
+		public function exists(string $key): bool;
 
 		/**
 		 * Sets the given key's value. This method does not have to be executed synchronously with other processes.
@@ -19,7 +19,7 @@
 		 *
 		 * @return bool
 		 */
-		public function set($key, $value);
+		public function set(string $key, $value): bool;
 
 		/**
 		 * Retrieves a value from the store.
@@ -28,7 +28,7 @@
 		 *
 		 * @return int|float
 		 */
-		public function get($key);
+		public function get(string $key);
 
 		/**
 		 * Adds a new item to the store only if the given key does not already exist.
@@ -38,7 +38,7 @@
 		 *
 		 * @return bool
 		 */
-		public function create($key, $value);
+		public function create(string $key, $value): bool;
 
 		/**
 		 * Increments the value of a key in the store. This method MUST be executed such that simultaneous increments
@@ -50,7 +50,7 @@
 		 *
 		 * @return bool
 		 */
-		public function increment($key, $step = 1, $initialValue = 0);
+		public function increment(string $key, $step = 1, $initialValue = 0): bool;
 
 		/**
 		 * Decrements the value of a key in the store. This method MUST be executed such that simultaneous decrements
@@ -62,7 +62,7 @@
 		 *
 		 * @return bool
 		 */
-		public function decrement($key, $step = 1, $initialValue = 0);
+		public function decrement(string $key, $step = 1, $initialValue = 0): bool;
 
 		/**
 		 * Removes a key from the store.
@@ -71,7 +71,7 @@
 		 *
 		 * @return bool
 		 */
-		public function delete($key);
+		public function delete(string $key): bool;
 
 		/**
 		 * Changes the value of a key using the return value of `$mutator`. This method MUST be executed such that
@@ -88,22 +88,25 @@
 		 *
 		 * @return bool
 		 */
-		public function modify($key, callable $mutator, $timeout = 500);
+		public function modify(string $key, callable $mutator, int $timeout = 500): bool;
 
 		/**
-		 * Searches the store for a given prefix, and returns an iterator that provides the key and value of the items
+		 * Searches the store for a given prefix, and returns a generator that provides the key and value of the items
 		 * in the store that matched the prefix.
+		 *
+		 * Each step of the generator will return an array containing two elements, the key and it's value, in that
+		 * order.
 		 *
 		 * @param string $prefix
 		 *
-		 * @return \Iterator
+		 * @return \Generator|array
 		 */
-		public function search($prefix);
+		public function search(string $prefix): \Generator;
 
 		/**
 		 * Deletes all items from the store.
 		 *
 		 * @return bool
 		 */
-		public function clear();
+		public function clear(): bool;
 	}

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -99,7 +99,7 @@
 		 *
 		 * @param string $prefix
 		 *
-		 * @return \Generator|array
+		 * @return \Generator|array[]
 		 */
 		public function search(string $prefix): \Generator;
 

--- a/src/Adapter/AdapterInterface.php
+++ b/src/Adapter/AdapterInterface.php
@@ -97,6 +97,11 @@
 		 * Each step of the generator will return an array containing two elements, the key and it's value, in that
 		 * order.
 		 *
+		 * Implementations should ensure that the keys returned from this method will function as expected when used
+		 * with other methods of the _same instance of the adapter_. That is to say, any prefixes or transformations
+		 * applied to keys internally should be stripped before being returned from this method, such that passing a
+		 * key returned by this method to another method (e.g. {@see AdapterInterface::set()}) should update the key.
+		 *
 		 * @param string $prefix
 		 *
 		 * @return \Generator|array[]

--- a/src/Adapter/Apcu/ApcuAdapter.php
+++ b/src/Adapter/Apcu/ApcuAdapter.php
@@ -1,7 +1,7 @@
 <?php /** @noinspection PhpComposerExtensionStubsInspection */
-	namespace DaybreakStudios\PrometheusClient\Adapter;
+	namespace DaybreakStudios\PrometheusClient\Adapter\Apcu;
 
-	use DaybreakStudios\PrometheusClient\Adapter\Apcu\FloatSupport;
+	use DaybreakStudios\PrometheusClient\Adapter\AdapterInterface;
 	use DaybreakStudios\PrometheusClient\Adapter\Exceptions\AdapterException;
 
 	class ApcuAdapter implements AdapterInterface {

--- a/src/Adapter/Apcu/ApcuIteratorWrapper.php
+++ b/src/Adapter/Apcu/ApcuIteratorWrapper.php
@@ -1,5 +1,5 @@
 <?php /** @noinspection PhpComposerExtensionStubsInspection */
-	namespace DaybreakStudios\PrometheusClient\Adapter;
+	namespace DaybreakStudios\PrometheusClient\Adapter\Apcu;
 
 	class ApcuIteratorWrapper implements \Iterator {
 		/**

--- a/src/Adapter/Apcu/FloatSupport.php
+++ b/src/Adapter/Apcu/FloatSupport.php
@@ -1,5 +1,5 @@
 <?php
-	namespace DaybreakStudios\PrometheusClient\Collector;
+	namespace DaybreakStudios\PrometheusClient\Adapter\Apcu;
 
 	final class FloatSupport {
 		/**

--- a/src/Adapter/ApcuAdapter.php
+++ b/src/Adapter/ApcuAdapter.php
@@ -116,9 +116,9 @@
 		/**
 		 * Decodes a stored value for general use.
 		 *
-		 * @param int $value
+		 * @param int|float $value
 		 *
-		 * @return int|float
+		 * @return int
 		 */
 		protected function decode($value) {
 			return FloatSupport::decode($value);

--- a/src/Adapter/ApcuAdapter.php
+++ b/src/Adapter/ApcuAdapter.php
@@ -8,35 +8,35 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function exists($key) {
+		public function exists(string $key): bool {
 			return apcu_exists($key);
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function set($key, $value) {
+		public function set(string $key, $value): bool {
 			return apcu_store($key, $this->encode($value));
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function get($key) {
+		public function get(string $key) {
 			return $this->decode(apcu_fetch($key));
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function create($key, $value) {
+		public function create(string $key, $value): bool {
 			return apcu_add($key, $this->encode($value));
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function increment($key, $step = 1, $initialValue = 0) {
+		public function increment(string $key, $step = 1, $initialValue = 0): bool {
 			$this->create($key, $initialValue);
 
 			return $this->modify(
@@ -50,7 +50,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function decrement($key, $step = 1, $initialValue = 0) {
+		public function decrement(string $key, $step = 1, $initialValue = 0): bool {
 			$this->create($key, $initialValue);
 
 			return $this->modify(
@@ -64,14 +64,14 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function delete($key) {
+		public function delete(string $key): bool {
 			return apcu_delete($key);
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function modify($key, callable $mutator, $timeout = 500) {
+		public function modify(string $key, callable $mutator, $timeout = 500): bool {
 			$startTime = microtime(true);
 			$done = false;
 
@@ -90,14 +90,15 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function search($prefix) {
-			return new ApcuIteratorWrapper(new \APCUIterator('/' . str_replace('/^', '\\/', $prefix) . '/'));
+		public function search(string $prefix): \Generator {
+			foreach (new \APCUIterator('/' . str_replace('/^', '\\/', $prefix) . '/') as $key => $value)
+				yield [$key, $value];
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function clear() {
+		public function clear(): bool {
 			return apcu_clear_cache();
 		}
 

--- a/src/Adapter/ApcuAdapter.php
+++ b/src/Adapter/ApcuAdapter.php
@@ -1,8 +1,8 @@
 <?php /** @noinspection PhpComposerExtensionStubsInspection */
 	namespace DaybreakStudios\PrometheusClient\Adapter;
 
+	use DaybreakStudios\PrometheusClient\Adapter\Apcu\FloatSupport;
 	use DaybreakStudios\PrometheusClient\Adapter\Exceptions\AdapterException;
-	use DaybreakStudios\PrometheusClient\Collector\FloatSupport;
 
 	class ApcuAdapter implements AdapterInterface {
 		/**

--- a/src/Adapter/Filesystem/FilesystemAdapter.php
+++ b/src/Adapter/Filesystem/FilesystemAdapter.php
@@ -1,8 +1,7 @@
 <?php
-	namespace DaybreakStudios\PrometheusClient\Adapter;
+	namespace DaybreakStudios\PrometheusClient\Adapter\Filesystem;
 
-	use DaybreakStudios\PrometheusClient\Adapter\Filesystem\FilesystemIterator;
-	use DaybreakStudios\PrometheusClient\Adapter\Filesystem\FilesystemLock;
+	use DaybreakStudios\PrometheusClient\Adapter\AdapterInterface;
 
 	class FilesystemAdapter implements AdapterInterface {
 		/**

--- a/src/Adapter/Filesystem/FilesystemIterator.php
+++ b/src/Adapter/Filesystem/FilesystemIterator.php
@@ -1,8 +1,6 @@
 <?php
 	namespace DaybreakStudios\PrometheusClient\Adapter\Filesystem;
 
-	use DaybreakStudios\PrometheusClient\Adapter\FilesystemAdapter;
-
 	class FilesystemIterator implements \Iterator {
 		/**
 		 * @var \ArrayIterator

--- a/src/Adapter/FilesystemAdapter.php
+++ b/src/Adapter/FilesystemAdapter.php
@@ -28,7 +28,7 @@
 		 *
 		 * @throws \RuntimeException if $basePath is not readable or writable by PHP
 		 */
-		public function __construct($basePath, $lockSuffix = '.lock') {
+		public function __construct(string $basePath, string $lockSuffix = '.lock') {
 			$this->basePath = rtrim($basePath, '\\/');
 			$this->lockSuffix = $lockSuffix;
 
@@ -53,7 +53,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function get($key, $def = null) {
+		public function get(string $key, $def = null) {
 			if (!$this->exists($key))
 				return $def;
 
@@ -118,7 +118,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function modify(string $key, callable $mutator, $timeout = 500): bool {
+		public function modify(string $key, callable $mutator, int $timeout = 500): bool {
 			if (!$this->exists($key))
 				return false;
 
@@ -175,7 +175,7 @@
 		 *
 		 * @return string
 		 */
-		protected function getPath($key) {
+		protected function getPath(string $key): string {
 			return $this->basePath . DIRECTORY_SEPARATOR . $this->encodeFilename($key);
 		}
 
@@ -186,7 +186,7 @@
 		 *
 		 * @return string
 		 */
-		protected function encodeFilename($key) {
+		protected function encodeFilename(string $key): string {
 			if (!isset($this->keyCache[$key]))
 				$this->keyCache[$key] = strtr(base64_encode($key), '=+/', '-_.');
 
@@ -200,7 +200,7 @@
 		 *
 		 * @return string
 		 */
-		protected function decodeFilename($encodedFilename) {
+		protected function decodeFilename(string $encodedFilename): string {
 			return base64_decode(strtr($encodedFilename, '-_.', '=+/'));
 		}
 
@@ -211,7 +211,7 @@
 		 *
 		 * @return string
 		 */
-		protected function serialize($value) {
+		protected function serialize($value): string {
 			return serialize($value);
 		}
 
@@ -222,7 +222,7 @@
 		 *
 		 * @return mixed
 		 */
-		protected function unserialize($data) {
+		protected function unserialize(string $data) {
 			return unserialize($data);
 		}
 	}

--- a/src/Adapter/FilesystemAdapter.php
+++ b/src/Adapter/FilesystemAdapter.php
@@ -39,14 +39,14 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function exists($key) {
+		public function exists(string $key): bool {
 			return file_exists($this->getPath($key));
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function set($key, $value) {
+		public function set(string $key, $value): bool {
 			return file_put_contents($this->getPath($key), $this->serialize($value)) !== false;
 		}
 
@@ -63,7 +63,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function create($key, $value) {
+		public function create(string $key, $value): bool {
 			if ($this->exists($key))
 				return false;
 
@@ -75,7 +75,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function increment($key, $step = 1, $initialValue = 0) {
+		public function increment(string $key, $step = 1, $initialValue = 0): bool {
 			$this->create($key, $initialValue);
 
 			return $this->modify(
@@ -89,7 +89,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function decrement($key, $step = 1, $initialValue = 0) {
+		public function decrement(string $key, $step = 1, $initialValue = 0): bool {
 			$this->create($key, $initialValue);
 
 			return $this->modify(
@@ -103,7 +103,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function delete($key) {
+		public function delete(string $key): bool {
 			if (!$this->exists($key))
 				return false;
 
@@ -118,7 +118,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function modify($key, callable $mutator, $timeout = 500) {
+		public function modify(string $key, callable $mutator, $timeout = 500): bool {
 			if (!$this->exists($key))
 				return false;
 
@@ -138,9 +138,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function search($prefix) {
-			$keys = [];
-
+		public function search(string $prefix): \Generator {
 			foreach (scandir($this->basePath) as $item) {
 				// Ignore any dotfiles in the directory (to support things like .gitkeep / .gitignore)
 				if (strpos($item, '.') === 0)
@@ -150,17 +148,14 @@
 
 				$key = $this->decodeFilename($item);
 
-				if (strpos($key, $prefix) === 0)
-					$keys[] = $key;
+				yield [$key, $this->get($key)];
 			}
-
-			return new FilesystemIterator($this, $keys);
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function clear() {
+		public function clear(): bool {
 			foreach (scandir($this->basePath) as $item) {
 				$path = $this->basePath . DIRECTORY_SEPARATOR . $item;
 

--- a/src/Adapter/MemoryAdapter.php
+++ b/src/Adapter/MemoryAdapter.php
@@ -1,0 +1,107 @@
+<?php
+	namespace DaybreakStudios\PrometheusClient\Adapter;
+
+	/**
+	 * Stores metrics in-memory. Probably has limited uses outside of testing and debugging, as values will be discarded
+	 * at the end of every session, and cannot be shared between sessions.
+	 *
+	 * @package DaybreakStudios\PrometheusClient\Adapter
+	 */
+	class MemoryAdapter implements AdapterInterface {
+		protected $data = [];
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function exists(string $key): bool {
+			return isset($this->data[$key]);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function set(string $key, $value): bool {
+			$this->data[$key] = $value;
+
+			return true;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function get(string $key) {
+			return $this->data[$key] ?? 0;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function create(string $key, $value): bool {
+			if (!$this->exists($key)) {
+				$this->data[$key] = $value;
+
+				return true;
+			}
+
+			return false;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function increment(string $key, $step = 1, $initialValue = 0): bool {
+			$this->create($key, $initialValue);
+			$this->set($key, $this->get($key) + $step);
+
+			return true;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function decrement(string $key, $step = 1, $initialValue = 0): bool {
+			$this->create($key, $initialValue);
+			$this->set($key, $this->get($key) - $step);
+
+			return true;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function delete(string $key): bool {
+			$exists = $this->exists($key);
+
+			unset($this->data[$key]);
+
+			return $exists;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function modify(string $key, callable $mutator, int $timeout = 500): bool {
+			$this->set($key, call_user_func($mutator, $this->get($key)));
+
+			return true;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function search(string $prefix): \Generator {
+			foreach ($this->data as $key => $value) {
+				if (strpos($key, $prefix) === 0)
+					yield [$key, $value];
+			}
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function clear(): bool {
+			$this->data = [];
+
+			return true;
+		}
+	}

--- a/src/Adapter/Redis/RedisAdapter.php
+++ b/src/Adapter/Redis/RedisAdapter.php
@@ -1,8 +1,8 @@
 <?php
-	namespace DaybreakStudios\PrometheusClient\Adapter;
+	namespace DaybreakStudios\PrometheusClient\Adapter\Redis;
 
+	use DaybreakStudios\PrometheusClient\Adapter\AdapterInterface;
 	use DaybreakStudios\PrometheusClient\Adapter\Exceptions\AdapterException;
-	use DaybreakStudios\PrometheusClient\Adapter\Redis\RedisClientConfiguration;
 
 	class RedisAdapter implements AdapterInterface {
 		/**

--- a/src/Adapter/Redis/RedisAdapter.php
+++ b/src/Adapter/Redis/RedisAdapter.php
@@ -127,8 +127,8 @@
 		 * {@inheritdoc}
 		 */
 		public function clear(): bool {
-			foreach ($this->search('') as $item)
-				$this->delete($item[0]);
+			foreach ($this->search('') as [$key])
+				$this->delete($key);
 
 			return true;
 		}

--- a/src/Adapter/Redis/RedisClientConfiguration.php
+++ b/src/Adapter/Redis/RedisClientConfiguration.php
@@ -1,0 +1,167 @@
+<?php
+	namespace DaybreakStudios\PrometheusClient\Adapter\Redis;
+
+	class RedisClientConfiguration {
+		public const DEFAULT_KEY_PREFIX = 'dbstudios_prom:';
+
+		/**
+		 * @var string
+		 */
+		protected $host;
+
+		/**
+		 * @var string
+		 */
+		protected $keyPrefix;
+
+		/**
+		 * @var int
+		 */
+		protected $port = 6379;
+
+		/**
+		 * @var float
+		 */
+		protected $timeout = 0.0;
+
+		/**
+		 * @var int
+		 */
+		protected $retryInterval = 0;
+
+		/**
+		 * @var float
+		 */
+		protected $retryTimeout = 0.0;
+
+		/**
+		 * @var string|null
+		 */
+		protected $password = null;
+
+		/**
+		 * RedisConfiguration constructor.
+		 *
+		 * @param string $host
+		 * @param string $keyPrefix
+		 */
+		public function __construct(string $host, string $keyPrefix = self::DEFAULT_KEY_PREFIX) {
+			$this->host = $host;
+			$this->keyPrefix = $keyPrefix;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getHost(): string {
+			return $this->host;
+		}
+
+		/**
+		 * @param string $host
+		 *
+		 * @return $this
+		 */
+		public function setHost(string $host) {
+			$this->host = $host;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getPort(): int {
+			return $this->port;
+		}
+
+		/**
+		 * @param int $port
+		 *
+		 * @return $this
+		 */
+		public function setPort(int $port) {
+			$this->port = $port;
+
+			return $this;
+		}
+
+		/**
+		 * @return float
+		 */
+		public function getTimeout(): float {
+			return $this->timeout;
+		}
+
+		/**
+		 * @param float $timeout
+		 *
+		 * @return $this
+		 */
+		public function setTimeout(float $timeout) {
+			$this->timeout = $timeout;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getRetryInterval(): int {
+			return $this->retryInterval;
+		}
+
+		/**
+		 * @param int $retryInterval
+		 *
+		 * @return $this
+		 */
+		public function setRetryInterval(int $retryInterval) {
+			$this->retryInterval = $retryInterval;
+
+			return $this;
+		}
+
+		/**
+		 * @return float
+		 */
+		public function getRetryTimeout(): float {
+			return $this->retryTimeout;
+		}
+
+		/**
+		 * @param float $retryTimeout
+		 *
+		 * @return $this
+		 */
+		public function setRetryTimeout(float $retryTimeout) {
+			$this->retryTimeout = $retryTimeout;
+
+			return $this;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getKeyPrefix(): string {
+			return $this->keyPrefix;
+		}
+
+		/**
+		 * @return string|null
+		 */
+		public function getPassword(): ?string {
+			return $this->password;
+		}
+
+		/**
+		 * @param string|null $password
+		 *
+		 * @return $this
+		 */
+		public function setPassword(?string $password) {
+			$this->password = $password;
+
+			return $this;
+		}
+	}

--- a/src/Adapter/RedisAdapter.php
+++ b/src/Adapter/RedisAdapter.php
@@ -58,7 +58,7 @@
 		public function increment(string $key, $step = 1, $initialValue = 0): bool {
 			$this->create($key, $initialValue);
 
-			return $this->getClient()->incrBy($this->config->getKeyPrefix() . $key, $step);
+			return $this->getClient()->incrByFloat($this->config->getKeyPrefix() . $key, $step);
 		}
 
 		/**
@@ -67,7 +67,9 @@
 		public function decrement(string $key, $step = 1, $initialValue = 0): bool {
 			$this->create($key, $initialValue);
 
-			return $this->getClient()->decrBy($this->config->getKeyPrefix() . $key, $step);
+			// Redis doesn't seem to implement a decrByFloat method, for some strange reason. So I guess we need to
+			// increment by the negated value of step instead?
+			return $this->getClient()->incrByFloat($this->config->getKeyPrefix() . $key, -$step);
 		}
 
 		/**

--- a/src/Adapter/RedisAdapter.php
+++ b/src/Adapter/RedisAdapter.php
@@ -1,0 +1,155 @@
+<?php
+	namespace DaybreakStudios\PrometheusClient\Adapter;
+
+	use DaybreakStudios\PrometheusClient\Adapter\Exceptions\AdapterException;
+	use DaybreakStudios\PrometheusClient\Adapter\Redis\RedisClientConfiguration;
+
+	class RedisAdapter implements AdapterInterface {
+		/**
+		 * @var RedisClientConfiguration
+		 */
+		protected $config;
+
+		/**
+		 * @var \Redis|null
+		 */
+		protected $redis = null;
+
+		/**
+		 * RedisAdapter constructor.
+		 *
+		 * @param RedisClientConfiguration $config
+		 */
+		public function __construct(RedisClientConfiguration $config) {
+			$this->config = $config;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function exists(string $key): bool {
+			return $this->getClient()->exists($this->config->getKeyPrefix() . $key);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function set(string $key, $value): bool {
+			return $this->getClient()->set($this->config->getKeyPrefix() . $key, $value);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function get(string $key) {
+			return $this->getClient()->get($this->config->getKeyPrefix() . $key);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function create(string $key, $value): bool {
+			return $this->getClient()->setnx($this->config->getKeyPrefix() . $key, $value);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function increment(string $key, $step = 1, $initialValue = 0): bool {
+			$this->create($key, $initialValue);
+
+			return $this->getClient()->incrBy($this->config->getKeyPrefix() . $key, $step);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function decrement(string $key, $step = 1, $initialValue = 0): bool {
+			$this->create($key, $initialValue);
+
+			return $this->getClient()->decrBy($this->config->getKeyPrefix() . $key, $step);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function delete(string $key): bool {
+			return $this->getClient()->del($this->config->getKeyPrefix() . $key) >= 1;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function modify(string $key, callable $mutator, $timeout = 500): bool {
+			$client = $this->getClient();
+			$startTime = microtime(true);
+
+			while (true) {
+				$client->watch($this->config->getKeyPrefix() . $key);
+
+				$value = call_user_func($mutator, $this->get($key));
+
+				$client->multi();
+				$client->set($this->config->getKeyPrefix() . $key, $value);
+
+				if ($client->exec()[0] ?? false)
+					break;
+				else if ((microtime(true) - $startTime) * 1000 >= $timeout)
+					throw AdapterException::compareAndSwapTimeout($timeout);
+			}
+
+			return true;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function search(string $prefix): \Generator {
+			$cursor = null;
+
+			while (
+				($keys = $this->getClient()->scan($cursor, $this->config->getKeyPrefix() . $prefix . '*')) !== false
+			) {
+				foreach ($keys as $key) {
+					$key = substr($key, strlen($this->config->getKeyPrefix()));
+
+					yield [
+						$key,
+						$this->get($key)
+					];
+				}
+			}
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function clear(): bool {
+			foreach ($this->search('') as $item)
+				$this->delete($item[0]);
+
+			return true;
+		}
+
+		/**
+		 * @return \Redis
+		 */
+		protected function getClient(): \Redis {
+			if ($this->redis === null) {
+				$this->redis = new \Redis();
+				$this->redis->connect(
+					$this->config->getHost(),
+					$this->config->getPort(),
+					$this->config->getTimeout(),
+					null,
+					$this->config->getRetryInterval(),
+					$this->config->getRetryTimeout()
+				);
+
+				if ($this->config->getPassword() !== null)
+					$this->redis->auth($this->config->getPassword());
+			}
+
+			return $this->redis;
+		}
+	}

--- a/src/Collector/AbstractCollector.php
+++ b/src/Collector/AbstractCollector.php
@@ -90,7 +90,7 @@
 		/**
 		 * @return string
 		 */
-		public function getStorageKeyPrefix() {
+		public function getStorageKeyPrefix(): string {
 			return $this->storageKeyPrefix;
 		}
 
@@ -99,7 +99,7 @@
 		 *
 		 * @return $this
 		 */
-		public function setStorageKeyPrefix($storageKeyPrefix) {
+		public function setStorageKeyPrefix(string $storageKeyPrefix) {
 			$this->storageKeyPrefix = $storageKeyPrefix;
 
 			return $this;
@@ -138,7 +138,7 @@
 		 *
 		 * @return string
 		 */
-		protected function getStorageKey(array $labels) {
+		protected function getStorageKey(array $labels): string {
 			return implode(
 				':',
 				array_merge(
@@ -153,14 +153,14 @@
 		/**
 		 * @return string
 		 */
-		protected function getStorageSearchPrefix() {
+		protected function getStorageSearchPrefix(): string {
 			return implode(':', $this->getStorageKeyParts()) . ':';
 		}
 
 		/**
-		 * @return array
+		 * @return string[]
 		 */
-		protected function getStorageKeyParts() {
+		protected function getStorageKeyParts(): array {
 			return [
 				$this->getStorageKeyPrefix(),
 				$this->getName(),
@@ -172,7 +172,7 @@
 		 *
 		 * @return string
 		 */
-		protected function encodeLabels(array $labels) {
+		protected function encodeLabels(array $labels): string {
 			ksort($labels);
 
 			return base64_encode(json_encode($labels));
@@ -183,7 +183,7 @@
 		 *
 		 * @return array
 		 */
-		protected function decodeLabels($encodedLabels) {
+		protected function decodeLabels(string $encodedLabels): array {
 			return json_decode(base64_decode($encodedLabels), true);
 		}
 

--- a/src/Collector/AbstractCollector.php
+++ b/src/Collector/AbstractCollector.php
@@ -112,7 +112,7 @@
 			$prefix = $this->getStorageSearchPrefix();
 			$samples = [];
 
-			foreach ($this->adapter->search($prefix) as $key => $value) {
+			foreach ($this->adapter->search($prefix) as [$key, $value]) {
 				$labels = $this->decodeLabels(substr($key, strrpos($key, ':') + 1));
 
 				$samples[] = new Sample($value, $labels);

--- a/src/Collector/AbstractCollector.php
+++ b/src/Collector/AbstractCollector.php
@@ -45,7 +45,13 @@
 		 * @param string           $help
 		 * @param string[]         $labelNames
 		 */
-		public function __construct(AdapterInterface $adapter, $name, $type, $help, array $labelNames = []) {
+		public function __construct(
+			AdapterInterface $adapter,
+			string $name,
+			string $type,
+			string $help,
+			array $labelNames = []
+		) {
 			$this->adapter = $adapter;
 			$this->name = $name;
 			$this->type = $type;
@@ -56,28 +62,28 @@
 		/**
 		 * @return string
 		 */
-		public function getName() {
+		public function getName(): string {
 			return $this->name;
 		}
 
 		/**
 		 * @return string
 		 */
-		public function getType() {
+		public function getType(): string {
 			return $this->type;
 		}
 
 		/**
 		 * @return string
 		 */
-		public function getHelp() {
+		public function getHelp(): string {
 			return $this->help;
 		}
 
 		/**
 		 * @return array|string[]
 		 */
-		public function getLabelNames() {
+		public function getLabelNames(): array {
 			return $this->labelNames;
 		}
 
@@ -102,7 +108,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function collect() {
+		public function collect(): array {
 			$prefix = $this->getStorageSearchPrefix();
 			$samples = [];
 

--- a/src/Collector/CollectorInterface.php
+++ b/src/Collector/CollectorInterface.php
@@ -9,33 +9,33 @@
 		 *
 		 * @return string
 		 */
-		public function getName();
+		public function getName(): string;
 
 		/**
 		 * Gets collector's type name.
 		 *
 		 * @return string
 		 */
-		public function getType();
+		public function getType(): string;
 
 		/**
 		 * Gets the collector's help text.
 		 *
 		 * @return string
 		 */
-		public function getHelp();
+		public function getHelp(): string;
 
 		/**
 		 * Gets the names of the labels used by the collector.
 		 *
 		 * @return string[]
 		 */
-		public function getLabelNames();
+		public function getLabelNames(): array;
 
 		/**
 		 * Collects all the metrics held by the collector.
 		 *
 		 * @return MetricInterface[]
 		 */
-		public function collect();
+		public function collect(): array;
 	}

--- a/src/Collector/Counter.php
+++ b/src/Collector/Counter.php
@@ -14,7 +14,7 @@
 		 * @param string           $help
 		 * @param string[]         $labelNames
 		 */
-		public function __construct(AdapterInterface $adapter, $name, $help, array $labelNames = []) {
+		public function __construct(AdapterInterface $adapter, string $name, string $help, array $labelNames = []) {
 			parent::__construct($adapter, $name, static::TYPE, $help, $labelNames);
 		}
 
@@ -24,7 +24,7 @@
 		 *
 		 * @return $this
 		 */
-		public function increment(array $labels = [], $step = 1) {
+		public function increment(array $labels = [], int $step = 1) {
 			$this->assertLabelsAreValid($labels);
 
 			$this->adapter->increment($this->getStorageKey($labels), $step);

--- a/src/Collector/Gauge.php
+++ b/src/Collector/Gauge.php
@@ -14,7 +14,7 @@
 		 * @param string           $help
 		 * @param array            $labelNames
 		 */
-		public function __construct(AdapterInterface $adapter, $name, $help, array $labelNames = []) {
+		public function __construct(AdapterInterface $adapter, string $name, string $help, array $labelNames = []) {
 			parent::__construct($adapter, $name, static::TYPE, $help, $labelNames);
 		}
 
@@ -47,8 +47,8 @@
 		}
 
 		/**
-		 * @param array $labels
-		 * @param int   $step
+		 * @param array     $labels
+		 * @param int|float $step
 		 *
 		 * @return $this
 		 */

--- a/src/Collector/Histogram.php
+++ b/src/Collector/Histogram.php
@@ -25,8 +25,8 @@
 		 */
 		public function __construct(
 			AdapterInterface $adapter,
-			$name,
-			$help,
+			string $name,
+			string $help,
 			array $buckets,
 			array $labelNames = []
 		) {
@@ -76,7 +76,7 @@
 		/**
 		 * @return MetricInterface[]
 		 */
-		public function collect() {
+		public function collect(): array {
 			$prefix = $this->getStorageSearchPrefix();
 			$bucketValues = [];
 
@@ -131,7 +131,7 @@
 		 *
 		 * @return void
 		 */
-		protected function assertLabelsAreValid(array $labels) {
+		protected function assertLabelsAreValid(array $labels): void {
 			if (isset($labels['le']))
 				throw new \InvalidArgumentException('Histograms cannot have a label named "le"');
 

--- a/src/Collector/Histogram.php
+++ b/src/Collector/Histogram.php
@@ -80,7 +80,7 @@
 			$prefix = $this->getStorageSearchPrefix();
 			$bucketValues = [];
 
-			foreach ($this->adapter->search($prefix) as $key => $value) {
+			foreach ($this->adapter->search($prefix) as [$key, $value]) {
 				$parts = explode(':', $key);
 				$count = sizeof($parts);
 

--- a/src/Collector/HistogramTimer.php
+++ b/src/Collector/HistogramTimer.php
@@ -1,0 +1,87 @@
+<?php
+	namespace DaybreakStudios\PrometheusClient\Collector;
+
+	use DaybreakStudios\PrometheusClient\Exception\HistogramTimerException;
+	use Symfony\Component\Stopwatch\Stopwatch;
+
+	class HistogramTimer {
+		/**
+		 * Indicates that the timer should observe values with millisecond precision.
+		 */
+		public const PRECISION_MILLISECONDS = 1;
+
+		/**
+		 * Indicates that the timer should observe values with second precision.
+		 */
+		public const PRECISION_SECONDS = 1000;
+
+		protected const STOPWATCH_NAME = 'histogram_timer';
+
+		/**
+		 * @var Histogram
+		 */
+		protected $histogram;
+
+		/**
+		 * @var Stopwatch
+		 */
+		protected $stopwatch;
+
+		/**
+		 * @var int
+		 */
+		protected $precision;
+
+		/**
+		 * @var bool
+		 */
+		protected $observed = false;
+
+		/**
+		 * Timer constructor.
+		 *
+		 * @param Histogram $histogram
+		 * @param int       $precision
+		 */
+		public function __construct(Histogram $histogram, int $precision = self::PRECISION_MILLISECONDS) {
+			$this->histogram = $histogram;
+			$this->precision = $precision;
+
+			$this->stopwatch = new Stopwatch();
+			$this->stopwatch->start(static::STOPWATCH_NAME);
+		}
+
+		/**
+		 * @param array $labels
+		 * @param bool  $throwOnMultiObserve
+		 *
+		 * @return $this
+		 * @throws HistogramTimerException If the timer is observed more than once (and $throwOnMultiObserve is `false`)
+		 */
+		public function observe(array $labels = [], bool $throwOnMultiObserve = true) {
+			if ($this->observed && $throwOnMultiObserve)
+				throw HistogramTimerException::multipleObservations();
+
+			if (!$this->observed) {
+				$event = $this->stopwatch->stop(static::STOPWATCH_NAME);
+				$this->histogram->observe((int)($event->getDuration() / $this->precision));
+
+				$this->observed = true;
+			}
+
+			return $this;
+		}
+
+		/**
+		 * @return void
+		 */
+		public function __destruct() {
+			if ($this->observed)
+				return;
+
+			trigger_error(
+				'A histogram timer is being destroyed without being observed. This is probably a mistake.',
+				E_USER_WARNING
+			);
+		}
+	}

--- a/src/CollectorRegistry.php
+++ b/src/CollectorRegistry.php
@@ -114,8 +114,12 @@
 		protected function getOfType(string $name, string $class, bool $throwOnMissing = true): ?CollectorInterface {
 			$collector = $this->get($name, $throwOnMissing);
 
-			if ($collector && !is_a($collector, $class))
-				throw CollectorRegistryException::collectorClassMismatch($name, $class, get_class($collector));
+			if ($collector && !is_a($collector, $class)) {
+				if ($throwOnMissing)
+					throw CollectorRegistryException::collectorClassMismatch($name, $class, get_class($collector));
+
+				$collector = null;
+			}
 
 			return $collector;
 		}

--- a/src/CollectorRegistry.php
+++ b/src/CollectorRegistry.php
@@ -83,8 +83,10 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function has(string $name): bool {
-			return isset($this->collectors[$name]);
+		public function has(string $name, ?string $class = null): bool {
+			$collector = $this->collectors[$name] ?? null;
+
+			return $collector !== null && ($class === null || is_a($collector, $class));
 		}
 
 		/**

--- a/src/CollectorRegistry.php
+++ b/src/CollectorRegistry.php
@@ -45,7 +45,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function get($name, $throwOnMissing = true) {
+		public function get(string $name, bool $throwOnMissing = true): ?CollectorInterface {
 			if (!$this->has($name)) {
 				if ($throwOnMissing)
 					throw CollectorRegistryException::collectorNotFound($name);
@@ -59,35 +59,38 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function getCounter($name, $throwOnMissing = true) {
+		public function getCounter(string $name, bool $throwOnMissing = true): ?Counter {
+			/** @noinspection PhpIncompatibleReturnTypeInspection */
 			return $this->getOfType($name, Counter::class, $throwOnMissing);
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function getGauge($name, $throwOnMissing = true) {
+		public function getGauge(string $name, bool $throwOnMissing = true): ?Gauge {
+			/** @noinspection PhpIncompatibleReturnTypeInspection */
 			return $this->getOfType($name, Gauge::class, $throwOnMissing);
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function getHistogram($name, $throwOnMissing = true) {
+		public function getHistogram(string $name, bool $throwOnMissing = true): ?Histogram {
+			/** @noinspection PhpIncompatibleReturnTypeInspection */
 			return $this->getOfType($name, Histogram::class, $throwOnMissing);
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function has($name) {
+		public function has(string $name): bool {
 			return isset($this->collectors[$name]);
 		}
 
 		/**
 		 * {@inheritdoc}
 		 */
-		public function collect() {
+		public function collect(): array {
 			$metrics = [];
 
 			foreach ($this->collectors as $collector)
@@ -104,10 +107,9 @@
 		 * @param bool   $throwOnMissing
 		 *
 		 * @return CollectorInterface|null
-		 * @throws CollectorRegistryException If `$throwOnMissing` is `true` and no collector was found
 		 * @throws CollectorRegistryException If a collector was found of a type of than the type specified by `$class`
 		 */
-		protected function getOfType($name, $class, $throwOnMissing = true) {
+		protected function getOfType(string $name, string $class, bool $throwOnMissing = true): ?CollectorInterface {
 			$collector = $this->get($name, $throwOnMissing);
 
 			if ($collector && !is_a($collector, $class))

--- a/src/CollectorRegistryInterface.php
+++ b/src/CollectorRegistryInterface.php
@@ -86,11 +86,12 @@
 		/**
 		 * Returns `true` if a collector exists with the given name.
 		 *
-		 * @param string $name
+		 * @param string      $name
+		 * @param string|null $class
 		 *
 		 * @return bool
 		 */
-		public function has(string $name): bool;
+		public function has(string $name, ?string $class = null): bool;
 
 		/**
 		 * Returns an array of data samples for all registered collectors.

--- a/src/CollectorRegistryInterface.php
+++ b/src/CollectorRegistryInterface.php
@@ -38,7 +38,7 @@
 		 * @return CollectorInterface|null
 		 * @throws CollectorRegistryException If `$throwOnMissing` is `true` and no collector was found
 		 */
-		public function get($name, $throwOnMissing = true);
+		public function get(string $name, bool $throwOnMissing = true): ?CollectorInterface;
 
 		/**
 		 * Retrieves a collector from the registry. If `$throwOnMissing` is false, `null` will be returned if a
@@ -50,10 +50,9 @@
 		 * @param bool   $throwOnMissing
 		 *
 		 * @return Counter|null
-		 * @throws CollectorRegistryException If `$throwOnMissing` is `true` and no collector was found
 		 * @throws CollectorRegistryException If a collector was found of a type of than {@see Counter}
 		 */
-		public function getCounter($name, $throwOnMissing = true);
+		public function getCounter(string $name, bool $throwOnMissing = true): ?Counter;
 
 		/**
 		 * Retrieves a collector from the registry. If `$throwOnMissing` is false, `null` will be returned if a
@@ -65,10 +64,9 @@
 		 * @param bool   $throwOnMissing
 		 *
 		 * @return Gauge|null
-		 * @throws CollectorRegistryException If `$throwOnMissing` is `true` and no collector was found
 		 * @throws CollectorRegistryException If a collector was found of a type of than {@see Gauge}
 		 */
-		public function getGauge($name, $throwOnMissing = true);
+		public function getGauge(string $name, bool $throwOnMissing = true): ?Gauge;
 
 		/**
 		 * Retrieves a collector from the registry. If `$throwOnMissing` is false, `null` will be returned if a
@@ -81,10 +79,9 @@
 		 * @param bool   $throwOnMissing
 		 *
 		 * @return Gauge|null
-		 * @throws CollectorRegistryException If `$throwOnMissing` is `true` and no collector was found
 		 * @throws CollectorRegistryException If a collector was found of a type of than {@see Histogram}
 		 */
-		public function getHistogram($name, $throwOnMissing = true);
+		public function getHistogram(string $name, bool $throwOnMissing = true): ?Histogram;
 
 		/**
 		 * Returns `true` if a collector exists with the given name.
@@ -93,12 +90,12 @@
 		 *
 		 * @return bool
 		 */
-		public function has($name);
+		public function has(string $name): bool;
 
 		/**
 		 * Returns an array of data samples for all registered collectors.
 		 *
 		 * @return MetricInterface[]
 		 */
-		public function collect();
+		public function collect(): array;
 	}

--- a/src/Exception/CollectorRegistryException.php
+++ b/src/Exception/CollectorRegistryException.php
@@ -7,7 +7,7 @@
 		 *
 		 * @return static
 		 */
-		public static function collectorAlreadyRegistered($name) {
+		public static function collectorAlreadyRegistered(string $name) {
 			return new static('A collector named ' . $name . ' has already been registered to this registry');
 		}
 
@@ -16,7 +16,7 @@
 		 *
 		 * @return static
 		 */
-		public static function collectorNotFound($name) {
+		public static function collectorNotFound(string $name) {
 			return new static('This registry has no collectors named ' . $name);
 		}
 
@@ -27,7 +27,7 @@
 		 *
 		 * @return CollectorRegistryException
 		 */
-		public static function collectorClassMismatch($name, $expectedClass, $actualClass) {
+		public static function collectorClassMismatch(string $name, string $expectedClass, string $actualClass) {
 			return new static(sprintf('Expected %s to be a %s, but got a %s', $name, $expectedClass, $actualClass));
 		}
 	}

--- a/src/Exception/HistogramTimerException.php
+++ b/src/Exception/HistogramTimerException.php
@@ -1,0 +1,13 @@
+<?php
+	namespace DaybreakStudios\PrometheusClient\Exception;
+
+	class HistogramTimerException extends \Exception {
+		/**
+		 * @return HistogramTimerException
+		 */
+		public static function multipleObservations() {
+			return new static(
+				'Observing the same timer more than once will cause duplicate results to be added to your histogram'
+			);
+		}
+	}

--- a/src/Export/Metric.php
+++ b/src/Export/Metric.php
@@ -30,7 +30,7 @@
 		 * @param string            $help
 		 * @param SampleInterface[] $samples
 		 */
-		public function __construct($name, $type, $help, array $samples) {
+		public function __construct(string $name, string $type, string $help, array $samples) {
 			$this->name = $name;
 			$this->type = $type;
 			$this->help = $help;
@@ -40,28 +40,28 @@
 		/**
 		 * @return string
 		 */
-		public function getName() {
+		public function getName(): string {
 			return $this->name;
 		}
 
 		/**
 		 * @return string
 		 */
-		public function getType() {
+		public function getType(): string {
 			return $this->type;
 		}
 
 		/**
 		 * @return string
 		 */
-		public function getHelp() {
+		public function getHelp(): string {
 			return $this->help;
 		}
 
 		/**
 		 * @return SampleInterface[]
 		 */
-		public function getSamples() {
+		public function getSamples(): array {
 			return $this->samples;
 		}
 	}

--- a/src/Export/MetricInterface.php
+++ b/src/Export/MetricInterface.php
@@ -7,24 +7,24 @@
 		 *
 		 * @return string
 		 */
-		public function getName();
+		public function getName(): string;
 
 		/**
 		 * Gets the type name of the samples in the group.
 		 *
 		 * @return string
 		 */
-		public function getType();
+		public function getType(): string;
 
 		/**
 		 * Gets the help text for the samples in the group.
 		 *
 		 * @return string
 		 */
-		public function getHelp();
+		public function getHelp(): string;
 
 		/**
 		 * @return SampleInterface[]
 		 */
-		public function getSamples();
+		public function getSamples(): array;
 	}

--- a/src/Export/Render/TextRenderer.php
+++ b/src/Export/Render/TextRenderer.php
@@ -10,7 +10,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function render(array $metrics) {
+		public function render(array $metrics): string {
 			usort(
 				$metrics,
 				function(MetricInterface $a, MetricInterface $b) {
@@ -57,7 +57,7 @@
 		/**
 		 * {@inheritdoc}
 		 */
-		public function getMimeType() {
+		public function getMimeType(): string {
 			return static::MIME_TYPE;
 		}
 
@@ -66,7 +66,7 @@
 		 *
 		 * @return string
 		 */
-		protected function sanitize($value) {
+		protected function sanitize(string $value): string {
 			$value = str_replace('\\', '\\\\', $value);
 			$value = str_replace("\n", '\\n', $value);
 

--- a/src/Export/RendererInterface.php
+++ b/src/Export/RendererInterface.php
@@ -9,12 +9,12 @@
 		 *
 		 * @return string
 		 */
-		public function render(array $metrics);
+		public function render(array $metrics): string;
 
 		/**
 		 * Returns a MIME type appropriate for the renderer.
 		 *
 		 * @return string
 		 */
-		public function getMimeType();
+		public function getMimeType(): string;
 	}

--- a/src/Export/Sample.php
+++ b/src/Export/Sample.php
@@ -24,7 +24,7 @@
 		 * @param array       $labels
 		 * @param string|null $name
 		 */
-		public function __construct($value, array $labels, $name = null) {
+		public function __construct($value, array $labels, ?string $name = null) {
 			$this->value = $value;
 			$this->labels = $labels;
 			$this->name = $name;
@@ -33,14 +33,14 @@
 		/**
 		 * @return string|null
 		 */
-		public function getName() {
+		public function getName(): ?string {
 			return $this->name;
 		}
 
 		/**
 		 * @return array
 		 */
-		public function getLabels() {
+		public function getLabels(): array {
 			return $this->labels;
 		}
 

--- a/src/Export/SampleInterface.php
+++ b/src/Export/SampleInterface.php
@@ -7,14 +7,14 @@
 		 *
 		 * @return string|null
 		 */
-		public function getName();
+		public function getName(): ?string;
 
 		/**
 		 * Gets the sample's labels.
 		 *
 		 * @return array
 		 */
-		public function getLabels();
+		public function getLabels(): array;
 
 		/**
 		 * Gets the value of the sample.

--- a/tests/Adapter/FilesystemAdapterTest.php
+++ b/tests/Adapter/FilesystemAdapterTest.php
@@ -1,7 +1,7 @@
 <?php
 	namespace Tests\DaybreakStudios\PrometheusClient\Adapter;
 
-	use DaybreakStudios\PrometheusClient\Adapter\FilesystemAdapter;
+	use DaybreakStudios\PrometheusClient\Adapter\Filesystem\FilesystemAdapter;
 
 	class FilesystemAdapterTest extends \PHPUnit_Framework_TestCase {
 		/**

--- a/tests/Adapter/RedisAdapterTest.php
+++ b/tests/Adapter/RedisAdapterTest.php
@@ -1,0 +1,157 @@
+<?php
+	namespace Tests\DaybreakStudios\PrometheusClient\Adapter;
+
+	use DaybreakStudios\PrometheusClient\Adapter\Redis\RedisClientConfiguration;
+	use DaybreakStudios\PrometheusClient\Adapter\RedisAdapter;
+
+	class RedisAdapterTest extends \PHPUnit_Framework_TestCase {
+		/**
+		 * @var RedisAdapter
+		 */
+		protected $adapter;
+
+		/**
+		 * @var \Redis;
+		 */
+		protected $redis;
+
+		public function testExists() {
+			$this->assertFalse($this->adapter->exists('testExists1'), 'it does not find non-existent keys');
+
+			$this->adapter->set('testExists2', 1);
+			$this->assertTrue($this->adapter->exists('testExists2'), 'it finds existent keys');
+		}
+
+		public function testGetSet() {
+			$this->adapter->set('testGetSet1', 1);
+
+			$this->assertEquals(1, $this->adapter->get('testGetSet1'), 'it sets and retrieves values');
+		}
+
+		public function testKeyPrefixesAreUsed() {
+			$this->adapter->set('testKeyPrefixesAreUsed1', 1);
+
+			$this->assertEquals(
+				1,
+				$this->redis->get(RedisClientConfiguration::DEFAULT_KEY_PREFIX . 'testKeyPrefixesAreUsed1'),
+				'it creates items with prefixed keys'
+			);
+		}
+
+		public function testCreate() {
+			$this->adapter->create('testCreate1', 1);
+			$this->assertEquals(1, $this->adapter->get('testCreate1'), 'it creates new items');
+
+			$this->adapter->create('testCreate1', 10);
+			$this->assertEquals(1, $this->adapter->get('testCreate1'), 'it does not overwrite existing items');
+		}
+
+		public function testIncrDecr() {
+			$this->adapter->set('testIncrDecr1', 1);
+
+			$this->adapter->increment('testIncrDecr1');
+			$this->assertEquals(2, $this->adapter->get('testIncrDecr1'), 'it increments values');
+
+			$this->adapter->decrement('testIncrDecr1');
+			$this->assertEquals(1, $this->adapter->get('testIncrDecr1'), 'it decrements values');
+
+			$this->adapter->increment('testIncrDecr1', 3);
+			$this->assertEquals(4, $this->adapter->get('testIncrDecr1'), 'it increments values with a step');
+
+			$this->adapter->decrement('testIncrDecr1', 2);
+			$this->assertEquals(2, $this->adapter->get('testIncrDecr1'), 'it decrements values with a step');
+
+			$this->adapter->increment('testIncrDecr2', 1, 5);
+			$this->assertEquals(6, $this->adapter->get('testIncrDecr2'), 'it increments values with an initial value');
+
+			$this->adapter->decrement('testIncrDecr3', 1, 5);
+			$this->assertEquals(4, $this->adapter->get('testIncrDecr3'), 'it decrements values with an initial value');
+		}
+
+		public function testDelete() {
+			$this->adapter->set('testDelete1', 1);
+			$this->adapter->delete('testDelete1');
+
+			$this->assertFalse($this->adapter->exists('testDelete1'), 'it deletes items');
+		}
+
+		public function testModify() {
+			$this->adapter->set('testModify1', 1);
+			$this->adapter->modify('testModify1', function(int $value) {
+				return $value + 3;
+			});
+
+			$this->assertEquals(4, $this->adapter->get('testModify1'), 'it modifies keys');
+		}
+
+		public function testSearch() {
+			$this->adapter->set('testSearch1', 1);
+			$this->adapter->set('testSearch2', 2);
+			$this->redis->set('testSearch3', 3);
+
+			$found = [];
+
+			foreach ($this->adapter->search('testSearch') as $item)
+				$found[$item[0]] = $item[1];
+
+			$this->assertArrayHasKey('testSearch1', $found);
+			$this->assertEquals(1, $found['testSearch1']);
+
+			$this->assertArrayHasKey('testSearch2', $found);
+			$this->assertEquals(2, $found['testSearch2']);
+
+			$this->assertArrayNotHasKey('testSearch3', $found);
+		}
+
+		public function testClear() {
+			$this->adapter->set('testClear1', 1);
+			$this->adapter->set('testClear2', 2);
+			$this->adapter->set('testClear3', 3);
+			$this->redis->set('testClear4', 4);
+
+			$this->adapter->clear();
+
+			$remainingCount = 0;
+
+			foreach ($this->adapter->search('') as $_)
+				++$remainingCount;
+
+			$this->assertEquals(0, $remainingCount, 'it deletes all of the "owned" keys');
+			$this->assertEquals(4, $this->redis->get('testClear4'), 'it does not delete non-prefixed keys');
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function setUp() {
+			$config = new RedisClientConfiguration(getenv('DBSTUDIOS_PROM_REDIS_HOST') ?: 'localhost');
+
+			if ($port = getenv('DBSTUDIOS_PROM_REDIS_PORT'))
+				$config->setPort($port);
+
+			if ($password = getenv('DBSTUDIOS_PROM_REDIS_PASSWORD'))
+				$config->setPassword($password);
+
+			$this->adapter = new RedisAdapter($config);
+
+			$this->redis = new \Redis();
+			$this->redis->connect(
+				$config->getHost(),
+				$config->getPort(),
+				$config->getTimeout(),
+				null,
+				$config->getRetryInterval(),
+				$config->getRetryTimeout()
+			);
+
+			if ($config->getPassword() !== null)
+				$this->redis->auth($config->getPassword());
+		}
+
+		protected function tearDown() {
+			$cursor = null;
+
+			while (($keys = $this->redis->scan($cursor)) !== false)
+				$this->redis->del($keys);
+		}
+	}

--- a/tests/Adapter/RedisAdapterTest.php
+++ b/tests/Adapter/RedisAdapterTest.php
@@ -94,13 +94,13 @@
 			foreach ($this->adapter->search('testSearch') as $item)
 				$found[$item[0]] = $item[1];
 
-			$this->assertArrayHasKey('testSearch1', $found);
-			$this->assertEquals(1, $found['testSearch1']);
+			$this->assertArrayHasKey('testSearch1', $found, 'it finds prefixed keys');
+			$this->assertEquals(1, $found['testSearch1'], 'it finds prefixed values');
 
-			$this->assertArrayHasKey('testSearch2', $found);
-			$this->assertEquals(2, $found['testSearch2']);
+			$this->assertArrayHasKey('testSearch2', $found, 'it finds prefixed keys');
+			$this->assertEquals(2, $found['testSearch2'], 'it finds prefixed values');
 
-			$this->assertArrayNotHasKey('testSearch3', $found);
+			$this->assertArrayNotHasKey('testSearch3', $found, 'it does not find non-prefixed keys');
 		}
 
 		public function testClear() {

--- a/tests/Adapter/RedisAdapterTest.php
+++ b/tests/Adapter/RedisAdapterTest.php
@@ -91,8 +91,8 @@
 
 			$found = [];
 
-			foreach ($this->adapter->search('testSearch') as $item)
-				$found[$item[0]] = $item[1];
+			foreach ($this->adapter->search('testSearch') as [$key, $value])
+				$found[$key] = $value;
 
 			$this->assertArrayHasKey('testSearch1', $found, 'it finds prefixed keys');
 			$this->assertEquals(1, $found['testSearch1'], 'it finds prefixed values');

--- a/tests/Adapter/RedisAdapterTest.php
+++ b/tests/Adapter/RedisAdapterTest.php
@@ -1,8 +1,8 @@
 <?php
 	namespace Tests\DaybreakStudios\PrometheusClient\Adapter;
 
+	use DaybreakStudios\PrometheusClient\Adapter\Redis\RedisAdapter;
 	use DaybreakStudios\PrometheusClient\Adapter\Redis\RedisClientConfiguration;
-	use DaybreakStudios\PrometheusClient\Adapter\RedisAdapter;
 
 	class RedisAdapterTest extends \PHPUnit_Framework_TestCase {
 		/**

--- a/tests/Adapter/RedisAdapterTest.php
+++ b/tests/Adapter/RedisAdapterTest.php
@@ -148,6 +148,9 @@
 				$this->redis->auth($config->getPassword());
 		}
 
+		/**
+		 * {@inheritdoc}
+		 */
 		protected function tearDown() {
 			$cursor = null;
 

--- a/tests/Adapter/runFilesystemAction.php
+++ b/tests/Adapter/runFilesystemAction.php
@@ -1,6 +1,7 @@
 #!/usr/bin/env php
 <?php
-	use DaybreakStudios\PrometheusClient\Adapter\FilesystemAdapter;
+
+	use DaybreakStudios\PrometheusClient\Adapter\Filesystem\FilesystemAdapter;
 
 	require __DIR__ . '/../../vendor/autoload.php';
 

--- a/tests/Collector/CounterTest.php
+++ b/tests/Collector/CounterTest.php
@@ -1,0 +1,43 @@
+<?php
+	namespace Tests\DaybreakStudios\PrometheusClient\Collector;
+
+	use DaybreakStudios\PrometheusClient\Adapter\MemoryAdapter;
+	use DaybreakStudios\PrometheusClient\Collector\Counter;
+
+	class CounterTest extends \PHPUnit_Framework_TestCase {
+		public function testInfoMethods() {
+			$counter = new Counter(new MemoryAdapter(), 'testInfoMethods1', 'Help text', ['testInfoMethodsLabel1']);
+
+			$this->assertEquals('counter', $counter->getType());
+			$this->assertEquals('testInfoMethods1', $counter->getName());
+			$this->assertEquals('Help text', $counter->getHelp());
+			$this->assertEquals(['testInfoMethodsLabel1'], $counter->getLabelNames());
+		}
+
+		public function testUpdateCollect() {
+			$counter = new Counter(new MemoryAdapter(), 'testUpdateCollect1', '', ['testUpdateCollectLabel1']);
+
+			$this->assertEmpty($counter->collect()[0]->getSamples(), 'it initializes without any samples');
+
+			$counter->increment(['testUpdateCollectLabel1' => 0]);
+			$this->assertEquals(
+				1,
+				$counter->collect()[0]->getSamples()[0]->getValue(),
+				'it increments by one without a step'
+			);
+
+			$counter->increment(['testUpdateCollectLabel1' => 0], 2);
+			$this->assertEquals(3, $counter->collect()[0]->getSamples()[0]->getValue(), 'it increments with a step');
+
+			$counter->increment(['testUpdateCollectLabel1' => 3]);
+			$metric = $counter->collect()[0];
+
+			$this->assertCount(2, $metric->getSamples(), 'it separates samples by label');
+
+			$this->assertEquals(['testUpdateCollectLabel1' => 0], $metric->getSamples()[0]->getLabels());
+			$this->assertEquals(3, $metric->getSamples()[0]->getValue());
+
+			$this->assertEquals(['testUpdateCollectLabel1' => 3], $metric->getSamples()[1]->getLabels());
+			$this->assertEquals(1, $metric->getSamples()[1]->getValue());
+		}
+	}

--- a/tests/Collector/GaugeTest.php
+++ b/tests/Collector/GaugeTest.php
@@ -1,0 +1,48 @@
+<?php
+	namespace Tests\DaybreakStudios\PrometheusClient\Collector;
+
+	use DaybreakStudios\PrometheusClient\Adapter\MemoryAdapter;
+	use DaybreakStudios\PrometheusClient\Collector\Gauge;
+
+	class GaugeTest extends \PHPUnit_Framework_TestCase {
+		public function testInfoMethods() {
+			$gauge = new Gauge(new MemoryAdapter(), 'testInfoMethods1', 'help text', ['testInfoMethodsLabel1']);
+
+			$this->assertEquals('gauge', $gauge->getType());
+			$this->assertEquals('testInfoMethods1', $gauge->getName());
+			$this->assertEquals('help text', $gauge->getHelp());
+			$this->assertEquals(['testInfoMethodsLabel1'], $gauge->getLabelNames());
+		}
+
+		public function testUpdateCollect() {
+			$gauge = new Gauge(new MemoryAdapter(), 'testUpdateCollect1', '', ['testUpdateCollectLabel1']);
+
+			$this->assertEmpty($gauge->collect()[0]->getSamples(), 'it initializes without any samples');
+
+			$gauge->increment(['testUpdateCollectLabel1' => 0]);
+			$this->assertEquals(1, $gauge->collect()[0]->getSamples()[0]->getValue(), 'it increments without a step');
+
+			$gauge->increment(['testUpdateCollectLabel1' => 0], 2);
+			$this->assertEquals(3, $gauge->collect()[0]->getSamples()[0]->getValue(), 'it increments with a step');
+
+			$gauge->decrement(['testUpdateCollectLabel1' => 0]);
+			$this->assertEquals(2, $gauge->collect()[0]->getSamples()[0]->getValue(), 'it decrements without a step');
+
+			$gauge->decrement(['testUpdateCollectLabel1' => 0], 2);
+			$this->assertEquals(0, $gauge->collect()[0]->getSamples()[0]->getValue(), 'it decrements with a step');
+
+			$gauge->set(5, ['testUpdateCollectLabel1' => 0]);
+			$this->assertEquals(5, $gauge->collect()[0]->getSamples()[0]->getValue(), 'it sets');
+
+			$gauge->set(10, ['testUpdateCollectLabel1' => 1]);
+			$metric = $gauge->collect()[0];
+
+			$this->assertCount(2, $metric->getSamples(), 'it separates samples by label');
+
+			$this->assertEquals(['testUpdateCollectLabel1' => 0], $metric->getSamples()[0]->getLabels());
+			$this->assertEquals(5, $metric->getSamples()[0]->getValue());
+
+			$this->assertEquals(['testUpdateCollectLabel1' => 1], $metric->getSamples()[1]->getLabels());
+			$this->assertEquals(10, $metric->getSamples()[1]->getValue());
+		}
+	}

--- a/tests/Collector/HistogramTest.php
+++ b/tests/Collector/HistogramTest.php
@@ -1,0 +1,106 @@
+<?php
+	namespace Tests\DaybreakStudios\PrometheusClient\Collector;
+
+	use DaybreakStudios\PrometheusClient\Adapter\MemoryAdapter;
+	use DaybreakStudios\PrometheusClient\Collector\Histogram;
+
+	class HistogramTest extends \PHPUnit_Framework_TestCase {
+		public function testInfoMethods() {
+			$histogram = new Histogram(
+				new MemoryAdapter(),
+				'testInfoMethods1',
+				'help text',
+				[1, 5, 10],
+				['testInfoMethodsLabel1']
+			);
+
+			$this->assertEquals('histogram', $histogram->getType());
+			$this->assertEquals('testInfoMethods1', $histogram->getName());
+			$this->assertEquals('help text', $histogram->getHelp());
+			$this->assertEquals(['testInfoMethodsLabel1'], $histogram->getLabelNames());
+
+			$prop = new \ReflectionProperty(Histogram::class, 'buckets');
+			$prop->setAccessible(true);
+
+			$this->assertEquals([1, 5, 10], $prop->getValue($histogram));
+		}
+
+		public function testUpdateCollect() {
+			$histogram = new Histogram(
+				new MemoryAdapter(),
+				'testUpdateCollect1',
+				'',
+				[1, 5, 10],
+				['testUpdateCollectLabel1']
+			);
+
+			$this->assertEmpty($histogram->collect()[0]->getSamples(), 'it initializes without any samples');
+
+			$histogram->observe(1, ['testUpdateCollectLabel1' => 0]);
+
+			$metric = $histogram->collect()[0];
+			[$le1, $le5, $le10, $leInf, $count, $sum] = $metric->getSamples();
+
+			$this->assertCount(
+				6,
+				$metric->getSamples(),
+				'it records one sample per bucket (and +Inf), plus sum and count'
+			);
+
+			$this->assertEquals('testUpdateCollect1_bucket', $le1->getName());
+			$this->assertArraySubset(['le' => 1], $le1->getLabels());
+			$this->assertEquals(1, $le1->getValue());
+
+			$this->assertEquals('testUpdateCollect1_bucket', $le5->getName());
+			$this->assertArraySubset(['le' => 5], $le5->getLabels());
+			$this->assertEquals(1, $le1->getValue());
+
+			$this->assertEquals('testUpdateCollect1_bucket', $le1->getName());
+			$this->assertArraySubset(['le' => 10], $le10->getLabels());
+			$this->assertEquals(1, $le10->getValue());
+
+			$this->assertEquals('testUpdateCollect1_bucket', $leInf->getName());
+			$this->assertArraySubset(['le' => '+Inf'], $leInf->getLabels());
+			$this->assertEquals(1, $leInf->getValue());
+
+			$this->assertEquals('testUpdateCollect1_count', $count->getName());
+			$this->assertEquals(1, $count->getValue());
+
+			$this->assertEquals('testUpdateCollect1_sum', $sum->getName());
+			$this->assertEquals(1, $sum->getValue());
+
+			$histogram->observe(3, ['testUpdateCollectLabel1' => 0]);
+
+			$metric = $histogram->collect()[0];
+			[$le1, $le5, $le10, $leInf, $count, $sum] = $metric->getSamples();
+
+			$this->assertEquals(1, $le1->getValue(), 'it places values into the correct bucket');
+			$this->assertEquals(2, $le5->getValue(), 'it places values into the correct bucket');
+			$this->assertEquals(2, $le10->getValue(), 'it places values into the correct bucket');
+			$this->assertEquals(2, $leInf->getValue(), 'it places values into the correct bucket');
+			$this->assertEquals(2, $count->getValue(), 'it increments the count for each observation');
+			$this->assertEquals(4, $sum->getValue(), 'it properly sums all observations');
+
+			$histogram->observe(3, ['testUpdateCollectLabel1' => 1]);
+
+			$metric = $histogram->collect()[0];
+			[$_, $_, $_, $_, $_, $_, $otherLe1, $otherLe5, $otherLe10, $otherLeInf, $otherCount, $otherSum] = $metric->getSamples(); // yikes
+
+			$this->assertCount(12, $metric->getSamples(), 'it separates samples by label');
+
+			$this->assertEquals(1, $le1->getValue(), 'it does not update buckets belonging to other labels');
+			$this->assertEquals(2, $le5->getValue(), 'it does not update buckets belonging to other labels');
+			$this->assertEquals(2, $le10->getValue(), 'it does not update buckets belonging to other labels');
+			$this->assertEquals(2, $leInf->getValue(), 'it does not update buckets belonging to other labels');
+			$this->assertEquals(2, $count->getValue(), 'it does not update buckets belonging to other labels');
+			$this->assertEquals(4, $sum->getValue(), 'it does not update buckets belonging to other labels');
+
+			$this->assertArraySubset(['testUpdateCollectLabel1' => 1], $otherLe1->getLabels(), 'it updates buckets belonging to the specified label');
+			$this->assertEquals(0, $otherLe1->getValue(), 'it updates buckets belonging to the specified label');
+			$this->assertEquals(1, $otherLe5->getValue(), 'it updates buckets belonging to the specified label');
+			$this->assertEquals(1, $otherLe10->getValue(), 'it updates buckets belonging to the specified label');
+			$this->assertEquals(1, $otherLeInf->getValue(), 'it updates buckets belonging to the specified label');
+			$this->assertEquals(1, $otherCount->getValue(), 'it updates buckets belonging to the specified label');
+			$this->assertEquals(3, $otherSum->getValue(), 'it updates buckets belonging to the specified label');
+		}
+	}

--- a/tests/CollectorRegistryTest.php
+++ b/tests/CollectorRegistryTest.php
@@ -1,0 +1,100 @@
+<?php
+	namespace Tests\DaybreakStudios\PrometheusClient;
+
+	use DaybreakStudios\PrometheusClient\Adapter\MemoryAdapter;
+	use DaybreakStudios\PrometheusClient\Collector\Counter;
+	use DaybreakStudios\PrometheusClient\Collector\Gauge;
+	use DaybreakStudios\PrometheusClient\CollectorRegistry;
+
+	class CollectorRegistryTest extends \PHPUnit_Framework_TestCase {
+		public function testRegisterUnregister() {
+			$registry = new CollectorRegistry();
+			$adapter = new MemoryAdapter();
+
+			$registry->register(new Counter($adapter, 'testRegisterUnregister1', ''));
+			$this->assertTrue($registry->has('testRegisterUnregister1', Counter::class), 'it registers collectors');
+
+			$registry->unregister('testRegisterUnregister1');
+			$this->assertFalse($registry->has('testRegisterUnregister1'), 'it unregisters collectors by name');
+
+			$registry->register($inst = new Counter($adapter, 'testRegisterUnregister2', ''));
+			$registry->unregister($inst);
+			$this->assertFalse($registry->has('testRegisterUnregister2'), 'it unregisters collectors by instance');
+		}
+
+		public function testHas() {
+			$registry = new CollectorRegistry();
+			$adapter = new MemoryAdapter();
+
+			$registry->register(new Counter($adapter, 'testHas1', ''));
+			$this->assertTrue($registry->has('testHas1'), 'it finds collectors by name');
+			$this->assertTrue($registry->has('testHas1', Counter::class), 'it finds collectors by name and class');
+
+			$registry->register(new Counter($adapter, 'testHas2', ''));
+			$this->assertFalse(
+				$registry->has('testHas2', Gauge::class),
+				'it does not match collects if class does not match'
+			);
+
+			$this->assertFalse($registry->has('testHas3'), 'it does not find non-existent collectors');
+		}
+
+		public function testGet() {
+			$registry = new CollectorRegistry();
+			$adapter = new MemoryAdapter();
+
+			$registry->register(new Counter($adapter, 'testGet1', ''));
+			$this->assertNotNull($registry->get('testGet1'), 'it retrieves collectors by name');
+
+			$this->assertNull($registry->get('testGet2', false), 'it does not retrieve non-existent collectors');
+
+			$registry->register(new Counter($adapter, 'testGet3', ''));
+			$this->assertNotNull($registry->getCounter('testGet3'), 'it retrieves counters');
+
+			$this->assertNull(
+				$registry->getGauge('testGet3', false),
+				'it does not retrieve collectors if types do not match'
+			);
+		}
+
+		public function testGetMissingThrow() {
+			$registry = new CollectorRegistry();
+
+			$this->expectExceptionMessage('This registry has no collectors named testGetMissingThrow1');
+			$registry->get('testGetMissingThrow1');
+
+			$registry->register(new Counter(new MemoryAdapter(), 'testGetMissingThrow2', ''));
+
+			$this->expectExceptionMessage(
+				sprintf('Expected testGetMissingThrow2 to be a %s, but got a %s', Gauge::class, Counter::class)
+			);
+			$registry->getGauge('testGetMissingThrow2');
+		}
+
+		public function testCollect() {
+			$registry = new CollectorRegistry();
+			$adapter = new MemoryAdapter();
+
+			$registry->register($counter = new Counter($adapter, 'testCollect1', ''));
+			$registry->register($gauge = new Gauge($adapter, 'testCollect2', '', ['testLabel1']));
+
+			$counter->increment([], 3);
+			$gauge->set(5.5, ['testLabel1' => 1]);
+
+			$metrics = $registry->collect();
+
+			$this->assertCount(2, $metrics);
+
+			$this->assertEquals('testCollect1', $metrics[0]->getName());
+			$this->assertEquals(Counter::TYPE, $metrics[0]->getType());
+			$this->assertCount(1, $metrics[0]->getSamples());
+			$this->assertEquals(3, $metrics[0]->getSamples()[0]->getValue());
+			$this->assertCount(0, $metrics[0]->getSamples()[0]->getLabels());
+
+			$this->assertEquals('testCollect2', $metrics[1]->getName());
+			$this->assertEquals(Gauge::TYPE, $metrics[1]->getType());
+			$this->assertCount(1, $metrics[1]->getSamples());
+			$this->assertEquals(5.5, $metrics[1]->getSamples()[0]->getValue());
+			$this->assertEquals(['testLabel1' => 1], $metrics[1]->getSamples()[0]->getLabels());
+		}
+	}

--- a/tests/Export/Render/TextRendererTest.php
+++ b/tests/Export/Render/TextRendererTest.php
@@ -1,0 +1,68 @@
+<?php
+	namespace Tests\DaybreakStudios\PrometheusClient\Export\Render;
+
+	use DaybreakStudios\PrometheusClient\Adapter\MemoryAdapter;
+	use DaybreakStudios\PrometheusClient\Collector\Counter;
+	use DaybreakStudios\PrometheusClient\Collector\Gauge;
+	use DaybreakStudios\PrometheusClient\Collector\Histogram;
+	use DaybreakStudios\PrometheusClient\CollectorRegistry;
+	use DaybreakStudios\PrometheusClient\Export\Render\TextRenderer;
+
+	class TextRendererTest extends \PHPUnit_Framework_TestCase {
+		public function testRender() {
+			$renderer = new TextRenderer();
+
+			$this->assertEquals('text/plain; version=0.0.4', $renderer->getMimeType());
+
+			$registry = new CollectorRegistry();
+			$adapter = new MemoryAdapter();
+
+			$registry->register($counter = new Counter($adapter, 'counter', 'counter help'));
+			$registry->register($counterWithLabels = new Counter($adapter, 'counter_with_labels', 'counter with labels help', ['label1']));
+			$registry->register($gauge = new Gauge($adapter, 'gauge', 'gauge help'));
+			$registry->register($histogram = new Histogram($adapter, 'histogram', 'histogram help', [1, 3, 5]));
+
+			$counter->increment();
+
+			$counterWithLabels->increment(['label1' => 0]);
+			$counterWithLabels->increment(['label1' => 1], 2);
+
+			$gauge->set(5.7);
+
+			$histogram->observe(1);
+			$histogram->observe(2);
+			$histogram->observe(3);
+			$histogram->observe(10);
+
+			$lines = array_filter(explode("\n", $renderer->render($registry->collect())));
+
+			/**
+			 * counter             = 3 output lines
+			 * counter_with_labels = 4 output lines
+			 * gauge               = 3 output lines
+			 * histogram           = 8 output lines
+			 *                     = 18 output lines total
+			 */
+			$this->assertCount(18, $lines);
+			$this->assertEquals([
+				'# HELP counter counter help',
+				'# TYPE counter counter',
+				'counter 1',
+				'# HELP counter_with_labels counter with labels help',
+				'# TYPE counter_with_labels counter',
+				'counter_with_labels{label1="0"} 1',
+				'counter_with_labels{label1="1"} 2',
+				'# HELP gauge gauge help',
+				'# TYPE gauge gauge',
+				'gauge 5.7',
+				'# HELP histogram histogram help',
+				'# TYPE histogram histogram',
+				'histogram_bucket{le="1"} 1',
+				'histogram_bucket{le="3"} 3',
+				'histogram_bucket{le="5"} 3',
+				'histogram_bucket{le="+Inf"} 4',
+				'histogram_count 4',
+				'histogram_sum 16',
+			], $lines);
+		}
+	}


### PR DESCRIPTION
## Changelog
- Bumped required PHP version to 7.3.
- Added support for using Redis to store Prometheus data.
- Added support for in-memory metric storage (for testing and debugging purposes).
- Added timing utility functions to `Histogram` (see `Histogram::startTimer()` and `Histogram::time()`); requires [`symfony/stopwatch`](https://packagist.org/packages/symfony/stopwatch).
- Fixed a bug wherein the `$throwOnMissing` argument was being ignored for calls to `CollectorRegistry::getCounter()`, `CollectorRegistry::getGauge()`, and `CollectorRegistry::getHistogram()`.

## Breaking Changes
- PHP versions before 7.3 are no longer supported.
- The `ApcuAdapter` and `FilesystemAdapter` have been moved to child namespaces under `DaybreakStudios\PrometheusClient\Adapter`.
- The return signature for `AdapterInterface::search()` has been changed to expect a generator instead of an iterator.